### PR TITLE
Fix for Issue (#3) & allow silent automake rules if desired

### DIFF
--- a/addons/AMD/configure.ac
+++ b/addons/AMD/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/BTF/configure.ac
+++ b/addons/BTF/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/CAMD/configure.ac
+++ b/addons/CAMD/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/CCOLAMD/configure.ac
+++ b/addons/CCOLAMD/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/CHOLMOD/Core/Makefile.am
+++ b/addons/CHOLMOD/Core/Makefile.am
@@ -1,0 +1,29 @@
+AM_CPPFLAGS = -I$(top_srcdir)/Include @SUITESPARSECONFIG_CFLAGS@ @CUBLAS_CFLAGS@
+
+noinst_LTLIBRARIES = libcore.la libcorel.la
+noinst_HEADERS = \
+	t_cholmod_change_factor.c \
+	t_cholmod_dense.c \
+	t_cholmod_transpose.c \
+	t_cholmod_triplet.c
+
+libcore_la_SOURCES = \
+	cholmod_aat.c \
+	cholmod_add.c \
+	cholmod_band.c \
+	cholmod_change_factor.c \
+	cholmod_common.c \
+	cholmod_complex.c \
+	cholmod_copy.c \
+	cholmod_dense.c \
+	cholmod_error.c \
+	cholmod_factor.c \
+	cholmod_memory.c \
+	cholmod_sparse.c \
+	cholmod_transpose.c \
+	cholmod_triplet.c
+
+libcorel_la_SOURCES = $(libcore_la_SOURCES)
+libcorel_la_CPPFLAGS = $(AM_CPPFLAGS) -DDLONG
+
+EXTRA_DIST = lesser.txt License.txt

--- a/addons/CHOLMOD/configure.ac
+++ b/addons/CHOLMOD/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h Include/cholmod_config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/COLAMD/configure.ac
+++ b/addons/COLAMD/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/CXSparse/configure.ac
+++ b/addons/CXSparse/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/KLU/configure.ac
+++ b/addons/KLU/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/LDL/configure.ac
+++ b/addons/LDL/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/RBio/configure.ac
+++ b/addons/RBio/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/SPQR/configure.ac
+++ b/addons/SPQR/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CXX

--- a/addons/SuiteSparse_config/configure.ac
+++ b/addons/SuiteSparse_config/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/addons/UMFPACK/Source/Makefile.am
+++ b/addons/UMFPACK/Source/Makefile.am
@@ -121,153 +121,153 @@ GN = $(addsuffix .lo, $(subst umfpack_,umfpack_gn_,$(GENERIC)))
 #-------------------------------------------------------------------------------
 
 umf_i_%.lo: umf_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -c $< -o $@
 
 umf_l_%.lo: umf_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -c $< -o $@
 
 #-------------------------------------------------------------------------------
 # compile each routine in the DI version
 #-------------------------------------------------------------------------------
 
 umf_di_%.lo: umf_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -c $< -o $@
 
 umf_di_%hsolve.lo: umf_%tsolve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DCONJUGATE_SOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DCONJUGATE_SOLVE -c $< -o $@
 
 umf_di_triplet_map_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DDO_MAP -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DDO_MAP -DDO_VALUES -c $< -o $@
 
 umf_di_triplet_map_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DDO_MAP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DDO_MAP -c $< -o $@
 
 umf_di_triplet_nomap_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DDO_VALUES -c $< -o $@
 
 umf_di_triplet_nomap_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -c $< -o $@
 
 umf_di_assemble_fixq.lo: umf_assemble.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DFIXQ -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DFIXQ -c $< -o $@
 
 umf_di_store_lu_drop.lo: umf_store_lu.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DDROP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DDROP -c $< -o $@
 
 umfpack_di_wsolve.lo: umfpack_solve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -DWSOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -DWSOLVE -c $< -o $@
 
 umfpack_di_%.lo: umfpack_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDINT -c $< -o $@
 
 #-------------------------------------------------------------------------------
 # compile each routine in the DL version
 #-------------------------------------------------------------------------------
 
 umf_dl_%.lo: umf_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -c $< -o $@
 
 umf_dl_%hsolve.lo: umf_%tsolve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DCONJUGATE_SOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DCONJUGATE_SOLVE -c $< -o $@
 
 umf_dl_triplet_map_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DDO_MAP -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DDO_MAP -DDO_VALUES -c $< -o $@
 
 umf_dl_triplet_map_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DDO_MAP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DDO_MAP -c $< -o $@
 
 umf_dl_triplet_nomap_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DDO_VALUES -c $< -o $@
 
 umf_dl_triplet_nomap_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -c $< -o $@
 
 umf_dl_assemble_fixq.lo: umf_assemble.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DFIXQ -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DFIXQ -c $< -o $@
 
 umf_dl_store_lu_drop.lo: umf_store_lu.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DDROP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DDROP -c $< -o $@
 
 umfpack_dl_wsolve.lo: umfpack_solve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -DWSOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -DWSOLVE -c $< -o $@
 
 umfpack_dl_%.lo: umfpack_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DDLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DDLONG -c $< -o $@
 
 #-------------------------------------------------------------------------------
 # compile each routine in the ZI version
 #-------------------------------------------------------------------------------
 
 umf_zi_%.lo: umf_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -c $< -o $@
 
 umf_zi_%hsolve.lo: umf_%tsolve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DCONJUGATE_SOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DCONJUGATE_SOLVE -c $< -o $@
 
 umf_zi_triplet_map_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DDO_MAP -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DDO_MAP -DDO_VALUES -c $< -o $@
 
 umf_zi_triplet_map_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DDO_MAP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DDO_MAP -c $< -o $@
 
 umf_zi_triplet_nomap_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DDO_VALUES -c $< -o $@
 
 umf_zi_triplet_nomap_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -c $< -o $@
 
 umf_zi_assemble_fixq.lo: umf_assemble.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DFIXQ -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DFIXQ -c $< -o $@
 
 umf_zi_store_lu_drop.lo: umf_store_lu.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DDROP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DDROP -c $< -o $@
 
 umfpack_zi_wsolve.lo: umfpack_solve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -DWSOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -DWSOLVE -c $< -o $@
 
 umfpack_zi_%.lo: umfpack_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZINT -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZINT -c $< -o $@
 
 #-------------------------------------------------------------------------------
 # compile each routine in the ZL version
 #-------------------------------------------------------------------------------
 
 umf_zl_%.lo: umf_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -c $< -o $@
 
 umf_zl_%hsolve.lo: umf_%tsolve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DCONJUGATE_SOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DCONJUGATE_SOLVE -c $< -o $@
 
 umf_zl_triplet_map_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DDO_MAP -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DDO_MAP -DDO_VALUES -c $< -o $@
 
 umf_zl_triplet_map_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DDO_MAP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DDO_MAP -c $< -o $@
 
 umf_zl_triplet_nomap_x.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DDO_VALUES -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DDO_VALUES -c $< -o $@
 
 umf_zl_triplet_nomap_nox.lo: umf_triplet.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -c $< -o $@
 
 umf_zl_assemble_fixq.lo: umf_assemble.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DFIXQ -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DFIXQ -c $< -o $@
 
 umf_zl_store_lu_drop.lo: umf_store_lu.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DDROP -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DDROP -c $< -o $@
 
 umfpack_zl_wsolve.lo: umfpack_solve.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -DWSOLVE -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -DWSOLVE -c $< -o $@
 
 umfpack_zl_%.lo: umfpack_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -DZLONG -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -DZLONG -c $< -o $@
 
 #-------------------------------------------------------------------------------
 # Create the generic routines (GN) using a generic rule
 #-------------------------------------------------------------------------------
 
 umfpack_gn_%.lo: umfpack_%.c $(noinst_HEADERS)
-	$(LTCOMPILE) -c $< -o $@
+	$(AM_V_CC)$(LTCOMPILE) -c $< -o $@
 
 lib_LTLIBRARIES = libumfpack.la
 

--- a/addons/UMFPACK/configure.ac
+++ b/addons/UMFPACK/configure.ac
@@ -5,7 +5,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([config])
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([dist-bzip2 foreign])
+
+# use silent rules if available - automake 1.11
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 LT_INIT
 AC_PROG_CC

--- a/build.bash
+++ b/build.bash
@@ -37,7 +37,7 @@ build_suitesparse_pkg() {
     # configure, build, test, and package
     autoreconf -vi && \
 	PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH" \
-	./configure && make distcheck
+	./configure && make distcheck PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:$PKG_CONFIG_PATH"
 
     # cleanup
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
This restores the missing addons/CHOLMOD/Core/Makefile.am, and also allows for silent make rules if desired.  This latter change required adding $(AM_V_CC)$(LTCOMPILE) in UMFPACK/Source/Makefile.am
